### PR TITLE
Feature: Add option to aggregate dataframe before plotting

### DIFF
--- a/pyopenms_viz/_core.py
+++ b/pyopenms_viz/_core.py
@@ -289,7 +289,6 @@ class BasePlot(ABC):
         """
         known_columns = [self.x, self.y]
         known_columns.extend([self.by] if self.by is not None else [])
-        known_columns.extend([self.z] if self.z is not None else [])
         return known_columns
 
     @property
@@ -920,6 +919,15 @@ class PeakMapPlot(BaseMSPlot, ABC):
     @property
     def _kind(self):
         return "peakmap"
+
+    @property
+    def known_columns(self) -> List[str]:
+        """
+        List of known columns in the data, if there are duplicates outside of these columns they will be grouped in aggregation if specified
+        """
+        known_columns = super().known_columns
+        known_columns.extend([self.z] if self.z is not None else [])
+        return known_columns
 
     def __init__(
         self,

--- a/pyopenms_viz/_core.py
+++ b/pyopenms_viz/_core.py
@@ -16,6 +16,7 @@ from numpy import ceil, log1p, log2
 
 from ._config import LegendConfig, FeatureConfig, _BasePlotConfig
 from ._misc import ColorGenerator, sturges_rule, freedman_diaconis_rule
+import warnings
 
 
 _common_kinds = ("line", "vline", "scatter")
@@ -128,6 +129,7 @@ class BasePlot(ABC):
         line_width: float | None = None,
         min_border: int | None = None,
         show_plot: bool | None = None,
+        aggregate_duplicates: bool | None = None,
         legend: LegendConfig | Dict | None = None,
         feature_config: FeatureConfig | Dict | None = None,
         _config: _BasePlotConfig | None = None,
@@ -165,6 +167,7 @@ class BasePlot(ABC):
         self.feature_config = feature_config
 
         self._config = _config
+        self.aggregate_duplicates = aggregate_duplicates
 
         if _config is not None:
             self._update_from_config(_config)
@@ -199,6 +202,35 @@ class BasePlot(ABC):
 
         self._load_extension()
         self._create_figure()
+
+    def _check_and_aggregate_duplicates(self):
+        """
+        Check if duplicate data is present and aggregate if specified.
+        Modifies self.data
+        """
+        # get all columns except for intensity column (typically this is 'y' however is 'z' for peakmaps)
+        if self.kind in {"peakmap"}:
+            known_columns_without_int = [
+                col for col in self.known_columns if col != self.z
+            ]
+        else:
+            known_columns_without_int = [
+                col for col in self.known_columns if col != self.y
+            ]
+
+        print(self.data[known_columns_without_int].drop_duplicates().shape[0])
+        if (
+            self.data[known_columns_without_int].drop_duplicates().shape[0]
+            < self.data.shape[0]
+        ):
+            if self.aggregate_duplicates:
+                self.data = (
+                    self.data.groupby(known_columns_without_int).sum().reset_index()
+                )
+            else:
+                warnings.warn(
+                    "Duplicate data detected, data will not be aggregated which may lead to unexpected plots. To enable aggregation set `aggregate_duplicates=True`."
+                )
 
     def _verify_column(self, colname: str | int, name: str) -> str:
         """fetch data from column name
@@ -247,6 +279,15 @@ class BasePlot(ABC):
         The kind of plot to assemble. Must be overridden by subclasses.
         """
         raise NotImplementedError
+
+    @property
+    def known_columns(self) -> List[str]:
+        """
+        List of known columns in the data, if there are duplicates outside of these columns they will be grouped in aggregation if specified
+        """
+        known_columns = [self.x, self.y]
+        known_columns.extend([self.by] if self.by is not None else [])
+        return known_columns
 
     @property
     def _interactive(self) -> bool:
@@ -302,7 +343,9 @@ class BasePlot(ABC):
         tooltips = kwargs.pop("tooltips", None)
         custom_hover_data = kwargs.pop("custom_hover_data", None)
 
-        newlines, legend = self.plot(fig, self.data, self.x, self.y, self.by, self.plot_3d, **kwargs)
+        newlines, legend = self.plot(
+            fig, self.data, self.x, self.y, self.by, self.plot_3d, **kwargs
+        )
 
         if legend is not None:
             self._add_legend(newlines, legend)
@@ -312,7 +355,9 @@ class BasePlot(ABC):
             self._add_tooltips(newlines, tooltips, custom_hover_data)
 
     @abstractmethod
-    def plot(cls, fig, data, x, y, by: str | None = None, plot_3d: bool = False, **kwargs):
+    def plot(
+        cls, fig, data, x, y, by: str | None = None, plot_3d: bool = False, **kwargs
+    ):
         """
         Create the plot
         """
@@ -407,6 +452,7 @@ class VLinePlot(BasePlot, ABC):
         """
         pass
 
+
 class ScatterPlot(BasePlot, ABC):
     @property
     def _kind(self):
@@ -487,6 +533,8 @@ class ChromatogramPlot(BaseMSPlot, ABC):
             self.annotation_data = None
         self.label_suffix = self.x  # set label suffix for bounding box
 
+        self._check_and_aggregate_duplicates()
+
         self.plot(self.data, self.x, self.y, **kwargs)
         if self.show_plot:
             self.show()
@@ -495,11 +543,11 @@ class ChromatogramPlot(BaseMSPlot, ABC):
         """
         Create the plot
         """
-        if 'line_color' not in kwargs:
+        if "line_color" not in kwargs:
             color_gen = ColorGenerator()
         else:
-            color_gen = kwargs['line_color']
-        
+            color_gen = kwargs["line_color"]
+
         tooltip_entries = {"retention time": x, "intensity": y}
         if "Annotation" in self.data.columns:
             tooltip_entries["annotation"] = "Annotation"
@@ -558,6 +606,27 @@ class SpectrumPlot(BaseMSPlot, ABC):
     def _kind(self):
         return "spectrum"
 
+    @property
+    def known_columns(self) -> List[str]:
+        """
+        List of known columns in the data, if there are duplicates outside of these columns they will be grouped in aggregation if specified
+        """
+        known_columns = super().known_columns
+        known_columns.extend([self.peak_color] if self.peak_color is not None else [])
+        known_columns.extend(
+            [self.ion_annotation] if self.ion_annotation is not None else []
+        )
+        known_columns.extend(
+            [self.sequence_annotation] if self.sequence_annotation is not None else []
+        )
+        known_columns.extend(
+            [self.custom_annotation] if self.custom_annotation is not None else []
+        )
+        known_columns.extend(
+            [self.annotation_color] if self.annotation_color is not None else []
+        )
+        return known_columns
+
     def __init__(
         self,
         data: DataFrame,
@@ -567,7 +636,9 @@ class SpectrumPlot(BaseMSPlot, ABC):
         mirror_spectrum: bool = False,
         relative_intensity: bool = False,
         bin_peaks: Union[Literal["auto"], bool] = "auto",
-        bin_method: Literal['none', 'sturges', 'freedman-diaconis'] = 'freedman-diaconis',
+        bin_method: Literal[
+            "none", "sturges", "freedman-diaconis"
+        ] = "freedman-diaconis",
         num_x_bins: int = 50,
         peak_color: str | None = None,
         annotate_top_n_peaks: int | None | Literal["all"] = 5,
@@ -590,11 +661,11 @@ class SpectrumPlot(BaseMSPlot, ABC):
         self.bin_peaks = bin_peaks
         self.bin_method = bin_method
         if self.bin_peaks == "auto":
-            if self.bin_method == 'sturges':
+            if self.bin_method == "sturges":
                 self.num_x_bins = sturges_rule(data, x)
-            elif self.bin_method == 'freedman-diaconis':
+            elif self.bin_method == "freedman-diaconis":
                 self.num_x_bins = freedman_diaconis_rule(data, x)
-            elif self.bin_method == 'none':
+            elif self.bin_method == "none":
                 self.num_x_bins = num_x_bins
         else:
             self.num_x_bins = num_x_bins
@@ -606,6 +677,8 @@ class SpectrumPlot(BaseMSPlot, ABC):
         self.custom_annotation = custom_annotation
         self.annotation_color = annotation_color
 
+        self._check_and_aggregate_duplicates()
+
         self.plot(x, y, **kwargs)
         # Show plot
         if self.show_plot:
@@ -613,7 +686,7 @@ class SpectrumPlot(BaseMSPlot, ABC):
 
     def plot(self, x, y, **kwargs):
         """Standard spectrum plot with m/z on x-axis, intensity on y-axis and optional mirror spectrum."""
-        
+
         # Prepare data
         spectrum, reference_spectrum = self._prepare_data(
             self.data, x, y, self.reference_spectrum
@@ -687,42 +760,24 @@ class SpectrumPlot(BaseMSPlot, ABC):
 
         self._modify_y_range((min_value, max_value), padding=(min_padding, max_padding))
 
-    def _bin_peaks(
-        self,
-        data: DataFrame,
-        x: str,
-        y: str
-    ) -> DataFrame:
+    def _bin_peaks(self, data: DataFrame, x: str, y: str) -> DataFrame:
         """
         Bin peaks based on x-axis values.
-        
+
         Args:
             data (DataFrame): The data to bin.
             x (str): The column name for the x-axis data.
             y (str): The column name for the y-axis data.
-            
+
         Returns:
             DataFrame: The binned data.
         """
         data[x] = cut(data[x], bins=self.num_x_bins)
-        # TODO: Find a better way to retain other columns
-        cols = [x]
-        if self.by is not None:
-            cols.append(self.by)
-        if self.peak_color is not None:
-            cols.append(self.peak_color)
-        if self.ion_annotation is not None:
-            cols.append(self.ion_annotation)
-        if self.sequence_annotation is not None:
-            cols.append(self.sequence_annotation)
-        if self.custom_annotation is not None:
-            cols.append(self.custom_annotation)
-        if self.annotation_color is not None:
-            cols.append(self.annotation_color)
-        
+
         # Group by x bins and calculate the mean intensity within each bin
+        known_columns_without_y = [col for col in self.known_columns if col != y]
         data = (
-            data.groupby(cols, observed=True)
+            data.groupby(known_columns_without_y, observed=True)
             .agg({y: "mean"})
             .reset_index()
         )
@@ -752,14 +807,13 @@ class SpectrumPlot(BaseMSPlot, ABC):
                 reference_spectrum[y] = (
                     reference_spectrum[y] / reference_spectrum[y].max() * 100
                 )
-        
+
         # Bin peaks if required
-        if self.bin_peaks == True or (self.bin_peaks == "auto"
-        ):
+        if self.bin_peaks == True or (self.bin_peaks == "auto"):
             spectrum = self._bin_peaks(spectrum, x, y)
             if reference_spectrum is not None:
                 reference_spectrum = self._bin_peaks(reference_spectrum, x, y)
-            
+
         return spectrum, reference_spectrum
 
     def _get_colors(
@@ -803,7 +857,7 @@ class SpectrumPlot(BaseMSPlot, ABC):
         data = data.sort_values(
             y, ascending=True if data[y].min() < 0 else False
         ).reset_index()
-        
+
         for i, row in data.iterrows():
             texts = []
             if i < top_n:
@@ -880,6 +934,7 @@ class PeakMapPlot(BaseMSPlot, ABC):
         # plot_3d: bool = False,
         **kwargs,
     ) -> None:
+
         # Copy data since it will be modified
         data = data.copy()
 
@@ -891,6 +946,10 @@ class PeakMapPlot(BaseMSPlot, ABC):
 
         self.zlabel = zlabel
         self.add_marginals = add_marginals
+
+        super().__init__(data, x, y, z=z, **kwargs)
+
+        self._check_and_aggregate_duplicates()
 
         if annotation_data is not None:
             self.annotation_data = annotation_data.copy()
@@ -904,8 +963,7 @@ class PeakMapPlot(BaseMSPlot, ABC):
 
         # Bin peaks if required
         if bin_peaks == True or (
-            data.shape[0] > num_x_bins * num_y_bins
-            and bin_peaks == "auto"
+            data.shape[0] > num_x_bins * num_y_bins and bin_peaks == "auto"
         ):
             data[x] = cut(data[x], bins=num_x_bins)
             data[y] = cut(data[y], bins=num_y_bins)
@@ -922,9 +980,7 @@ class PeakMapPlot(BaseMSPlot, ABC):
             else:
                 # Group by x and y bins and calculate the mean intensity within each bin
                 data = (
-                    data.groupby([x, y], observed=True)
-                    .agg({z: "mean"})
-                    .reset_index()
+                    data.groupby([x, y], observed=True).agg({z: "mean"}).reset_index()
                 )
             data[x] = data[x].apply(lambda interval: interval.mid).astype(float)
             data[y] = data[y].apply(lambda interval: interval.mid).astype(float)
@@ -937,13 +993,11 @@ class PeakMapPlot(BaseMSPlot, ABC):
         # Sort values by intensity in ascending order to plot highest intensity peaks last
         data = data.sort_values(z)
 
-        super().__init__(data, x, y, z=z, **kwargs)
-
         # if not plot_3d:
         self.plot(x, y, z, **kwargs)
         # else:
         #     self.plot_3d(x, y, z, **kwargs)
-            
+
         if self.show_plot:
             self.show()
 
@@ -970,10 +1024,10 @@ class PeakMapPlot(BaseMSPlot, ABC):
             y_fig = self.create_y_axis_plot(y, z, class_kwargs_copy)
 
             self.combine_plots(x_fig, y_fig)
-    
+
     # def plot_3d(self, x, y, z, **kwargs):
     #     class_kwargs, other_kwargs = self._separate_class_kwargs(**kwargs)
-        
+
     #     self.create_main_plot_3d(x, y, z, class_kwargs, other_kwargs)
     #     pass
 
@@ -999,7 +1053,7 @@ class PeakMapPlot(BaseMSPlot, ABC):
     # by default the main plot with marginals is plotted the same way as the main plot unless otherwise specified
     def create_main_plot_marginals(self, x, y, z, class_kwargs, other_kwargs):
         self.create_main_plot(x, y, z, class_kwargs, other_kwargs)
-        
+
     # @abstractmethod
     # def create_main_plot_3d(self, x, y, z, class_kwargs, other_kwargs):
     #     pass
@@ -1113,7 +1167,7 @@ class PlotAccessor:
         # Call the plot method of the selected backend
         if "backend" in kwargs:
             kwargs.pop("backend")
-        
+
         return plot_backend.plot(self._parent, x=x, y=y, kind=kind, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
When excluding columns from plotting that are present, this can lead to wonky plots. 

For example, if ion mobility is present in the underlying dataframe and is ignored in chromatogram plotting, we can end up with a plot like this
![image](https://github.com/user-attachments/assets/3149e93f-f66e-4881-a195-09fa87fdcf36)

This is because there is more than one point plotted at each RT and intensity (since they differ in IM).


In this PR I add a warning message that this is occurring because of duplicates. 
![image](https://github.com/user-attachments/assets/762d55d7-1935-4905-b21a-42044907cb19)

I also added the aggregate_duplicates option which will sum up the intensities of duplicate entries. 
If  aggregate_duplicates=True then we get a plot that is more in line with what is expected
![image](https://github.com/user-attachments/assets/914b7c1c-602e-47ec-8698-5ff21f93151e)

