### PR TITLE
remove: python 3.9 from project toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
-requires-python = ">=3.9, <=3.12"
+requires-python = ">=3.10, <=3.12"
 dependencies = ["pandas>=0.17"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### **User description**
Limit python version from 3.10 to 3.12 for changes in syntax to address #25


___

### **PR Type**
configuration changes


___

### **Description**
- Removed support for Python 3.9 in the `pyproject.toml` file.
- Updated the `requires-python` field to specify compatibility with Python versions 3.10 to 3.12.
- This change addresses syntax changes and aligns with the project's current Python version support strategy.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update Python version compatibility in project configuration</code></dd></summary>
<hr>

pyproject.toml

<li>Removed Python 3.9 from the list of supported versions.<br> <li> Updated the <code>requires-python</code> field to start from Python 3.10.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/pyopenms_viz/pull/26/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

