### PR TITLE
Plot peptide sequence with matched fragments indicated

### DIFF
--- a/sequenceplot.py
+++ b/sequenceplot.py
@@ -1,4 +1,4 @@
-def plot(ax, data, x=0.5, y=0.5, spacing=0.1, fontsize="xx-large", fontsize_frag="medium", frag_len=0.05):
+def plot(ax, data, x=0.5, y=0.5, spacing=0.06, fontsize="xx-large", fontsize_frag="medium", frag_len=0.06):
     """
     Plot peptide sequence with matched fragments indicated.
 
@@ -42,14 +42,27 @@ def plot(ax, data, x=0.5, y=0.5, spacing=0.1, fontsize="xx-large", fontsize_frag
         ion_i = int(i) if (i := annot[1:].rstrip("+")) else 1
         x_i = x + spacing / 2 + (ion_i - 1) * spacing
 
+        # Length of the fragment line.
+        if ion_type in "ax":
+            y_i = 2 * frag_len
+        elif ion_type in "by":
+            y_i = frag_len
+        elif ion_type in "cz":
+            y_i = 3 * frag_len
+        else:
+            # Ignore unknown ion types.
+            continue
+
+        # N-terminal fragmentation.
         if ion_type in "abc":
-            xs = [x_i, x_i, x_i + spacing / 4]
-            ys = [y, y + frag_len, y + frag_len * 4 / 3]
-            top = True
+            xs = [x_i, x_i, x_i - spacing / 2]
+            ys = [y, y + y_i, y + y_i]
+            nterm = True
+        # C-terminal fragmentation.
         elif ion_type in "xyz":
-            xs = [x_i - spacing / 4, x_i, x_i]
-            ys = [y - frag_len * 4 / 3, y - frag_len, y]
-            top = False
+            xs = [x_i + spacing / 2, x_i, x_i]
+            ys = [y - y_i, y - y_i, y]
+            nterm = False
         else:
             # Ignore unknown ion types.
             continue
@@ -60,11 +73,11 @@ def plot(ax, data, x=0.5, y=0.5, spacing=0.1, fontsize="xx-large", fontsize_frag
 
         ax.text(
             x_i,
-            y + frag_len * 5 / 3 if top else y - frag_len * 5 / 3,
+            y + (1.05 if nterm else -1.05) * y_i,
             annot,
             color=color,
             fontsize=fontsize_frag,
-            ha="center",
+            ha="right" if nterm else "left",
             transform=ax.transAxes,
-            va="top" if not top else "bottom",
+            va="top" if not nterm else "bottom",
         )

--- a/sequenceplot.py
+++ b/sequenceplot.py
@@ -1,0 +1,70 @@
+def plot(ax, data, x=0.5, y=0.5, spacing=0.1, fontsize="xx-large", fontsize_frag="medium", frag_len=0.05):
+    """
+    Plot peptide sequence with matched fragments indicated.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axes to plot on.
+    data : pandas.DataFrame
+        The spectrum dataframe.
+    x : float, optional
+        The center horizontal position of the peptide sequence.
+    y : float, optional
+        The center vertical position of the peptide sequence.
+    spacing : float, optional
+        The horizontal spacing between amino acids.
+    fontsize : str, optional
+        The font size of the amino acids.
+    fontsize_frag : str, optional
+        The font size of the fragment annotations.
+    frag_len : float, optional
+        The length of the fragment lines.
+    """
+    sequence = data["sequence"].iloc[0]
+    n_residues = len(sequence)
+
+    # Remap `x` position to be the left edge of the peptide.
+    x = x - n_residues * spacing / 2 + spacing / 2
+
+    # Plot the amino acids in the peptide.
+    for i, aa in enumerate(sequence):
+        ax.text(
+            *(x + i * spacing, y, aa),
+            fontsize=fontsize,
+            ha="center",
+            transform=ax.transAxes,
+            va="center",
+        )
+    # Indicate matched fragments.
+    for annot, color in zip(data["ion_annotation"], data["color_annotation"]):
+        ion_type = annot[0]
+        ion_i = int(i) if (i := annot[1:].rstrip("+")) else 1
+        x_i = x + spacing / 2 + (ion_i - 1) * spacing
+
+        if ion_type in "abc":
+            xs = [x_i, x_i, x_i + spacing / 4]
+            ys = [y, y + frag_len, y + frag_len * 4 / 3]
+            top = True
+        elif ion_type in "xyz":
+            xs = [x_i - spacing / 4, x_i, x_i]
+            ys = [y - frag_len * 4 / 3, y - frag_len, y]
+            top = False
+        else:
+            # Ignore unknown ion types.
+            continue
+
+        ax.plot(
+            xs, ys, clip_on=False, color=color, transform=ax.transAxes
+        )
+
+        ax.text(
+            x_i,
+            y + frag_len * 5 / 3 if top else y - frag_len * 5 / 3,
+            annot,
+            color=color,
+            fontsize=fontsize_frag,
+            ha="center",
+            transform=ax.transAxes,
+            va="top" if not top else "bottom",
+        )


### PR DESCRIPTION
As per discussion with @timosachsenberg, here's some functionality to plot a peptide sequence with matched fragments indicated.

- Currently it only supports matplotlib, as I don't really have experience with the two other plotting libraries.
- It's also not directly hooked into the DataFrame plotting backend yet, because I couldn't immediately figure out how to add it. It's probably more efficient if you give some pointers or modify the code than if I keep bumbling around.

Minor implementation details can be discussed. This is the output it would give using the simple test spectrum:
```
import matplotlib.pyplot as plt
import pandas as pd

import sequenceplot as sp


df = pd.read_csv("test/test_data/TestSpectrumDf.tsv", sep="\t")

df.loc[0, "ion_annotation"] = "a3+"
df.loc[2, "ion_annotation"] = "c2+"

print(df["ion_annotation"])

fig, ax = plt.subplots()

sp.plot(ax, df)

plt.savefig("sequenceplot.png", dpi=300)
plt.close()
```
![sequenceplot](https://github.com/user-attachments/assets/06a7f92b-fa98-4bba-94c4-d55cdfb38680)

Note the somewhat off y9-annotation because the peptide sequence isn't that long.

Some other minor issue is that if a certain fragmentation would be covered by multiple peaks with a different charge, these would be overlaid in a messy fashion. We can discuss whether to add some priority rules to avoid that.
