### PR TITLE
remove explcit TOC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,17 @@
 PyOpenMS-Viz
 ============
 
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+
+   Installation
+   User Guide
+   gallery/index
+   API
+
+
 Welcome to PyOpenMS-Viz Documentation! PyOpenMS-Viz is a visualization package for mass spectrometry data directly from pandas dataframes
 
 Key Features Include:
@@ -40,19 +51,6 @@ Plotting a Chromatogram
         ms_data = pd.read_csv("path/to/ms_data.csv")
         pd.set_option("plotting.backend", "ms_bokeh") # try changing backend to "ms_plotly" or "ms_matplotlib"
         ms_data.plot(x="rt", y="intensity", kind="chromatogram")
-
-
-User Guide
-**********
-
-.. toctree::
-   :maxdepth: 2
-   :glob:
-
-   Installation
-   User Guide
-   gallery/index
-   API
 
 
 Support


### PR DESCRIPTION
### **User description**
simplify starting page by removing explcit TOC.

Also test to see if readthedocs PR manager is working


___

### **PR Type**
documentation


___

### **Description**
- Simplified the starting page of the documentation by removing the explicit Table of Contents (TOC) from the User Guide section.
- Introduced a hidden TOC at the beginning of the document with a max depth of 1 to streamline the documentation layout.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.rst</strong><dd><code>Simplify and hide Table of Contents in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/index.rst

<li>Removed explicit Table of Contents (TOC) from the User Guide section.<br> <li> Added a hidden TOC at the beginning of the document with a max depth <br>of 1.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/pyopenms_viz/pull/33/files#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534">+11/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information