### PR TITLE
Added doc on how to adapt bin size in peakmap plots

### DIFF
--- a/docs/Parameters/PeakMap.rst
+++ b/docs/Parameters/PeakMap.rst
@@ -4,6 +4,24 @@ Peak Map
 Peak Maps can be plotted using kind = peakmap. Commonly in this plot, mass-to-charge is on the x-axis, retention time is on the y-axis and intensity is on the z-axis (or represented by color). The x and y axis can be changed based on use case, for example y can also be ion mobility. Using `plot_3d=True` enables 3D plotting. Currently 3D plotting only supported for `ms_matplotlib` and `ms_plotly` backends.
 
 
+Adapting Bin Size in Peak Map Plots
+-----------------------------------
+
+By default, the peak map uses binning to optimize visualization. You can **adjust the binning** level to balance between performance and detail.
+
+- **Low binning** (fewer details, faster rendering):
+
+  .. code-block:: python
+
+      df_ms_experiment.plot(x="RT", y="mz", z="inty", kind="peakmap", num_x_bins=10, num_y_bins=10)
+
+- **High binning** (more details, slower rendering):
+
+  .. code-block:: python
+
+      df_ms_experiment.plot(x="RT", y="mz", z="inty", kind="peakmap", num_x_bins=100, num_y_bins=100)
+
+If ``bin_peaks='auto'``, binning is automatically enabled for large datasets exceeding ``num_x_bins * num_y_bins`` peaks. Setting ``bin_peaks=False`` disables binning, at the cost of performance for large datasets.
 
 Parameters
 ----------

--- a/docs/Parameters/peakMapPlot.tsv
+++ b/docs/Parameters/peakMapPlot.tsv
@@ -15,7 +15,7 @@ xlabel	“”	str	Label for x axis
 ylabel 	“”	str	Label for y axis
 zlabel	'’	str	Label for z-axis
 show_plot	True	bool	Whether to display the plot. If plot is not shown, will return the plot object corresponding with the backend. If plot is displayed the method returns None
-bin_peaks	False	bool | “auto”	If True, will bin peaks based on specified number of bins in `num_x_bins`. If "auto", will automatically determine the number of bins based on the data using the strategy specified in `bin_method`. 
+bin_peaks	auto	bool | “auto”	If True, will bin peaks based on specified number of bins in `num_x_bins`. If "auto", will automatically determine the number of bins based on the data using the strategy specified in `bin_method`. 
 aggregation_method	“mean”	Literal[“mean”, “sum”, “max”]	How to aggregate duplicate entries
 num_x_bins	50	int	Number of x-bins in heatmap
 num_y_bins	50	int	Number of y-bins in heatmap

--- a/docs/gallery_scripts_template/plot_peakmap_binning_demonstration_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_peakmap_binning_demonstration_ms_matplotlib.py
@@ -19,10 +19,10 @@ response.raise_for_status()
 df = pd.read_csv(StringIO(response.text), sep="\t")
 
 
-fig, axs = plt.subplots(1, 3, figsize=(18, 6), sharex=True, sharey=True)
+fig, axs = plt.subplots(3, 1, figsize=(5, 15), sharex=True, sharey=True)
 
 
-binning_levels = [(10, 10), (50, 50), (100, 100)]
+binning_levels = [(10, 10), (40, 40), (100, 100)]
 
 for ax, (num_x_bins, num_y_bins) in zip(axs, binning_levels):
     
@@ -36,8 +36,13 @@ for ax, (num_x_bins, num_y_bins) in zip(axs, binning_levels):
         num_y_bins=num_y_bins,
         canvas=ax,
         title=f"Binning: {num_x_bins} x {num_y_bins}",
+        title_font_size=12,
+        show_plot = False,
+        xaxis_label_font_size=10,
+        yaxis_label_font_size=10,
+        xaxis_tick_font_size=9,
+        yaxis_tick_font_size=9,
     )
 
-
-fig.suptitle("Effect of Different Binning Levels in Peak Maps", fontsize=16)
-fig.tight_layout()
+fig.subplots_adjust(top=0.95, hspace=0.3, bottom=0.13)
+plt.show()

--- a/docs/gallery_scripts_template/plot_peakmap_binning_demonstration_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_peakmap_binning_demonstration_ms_matplotlib.py
@@ -1,0 +1,43 @@
+"""
+Plot Peakmap Binning Demonstration
+==================================
+
+This example demonstrates how different binning levels affect peak map visualization
+"""
+
+import pandas as pd
+import requests
+from io import StringIO
+import numpy as np
+import matplotlib.pyplot as plt
+
+pd.options.plotting.backend = "ms_matplotlib"
+
+url = "https://github.com/OpenMS/pyopenms_viz/releases/download/v0.1.5/TestMSExperimentDf.tsv"
+response = requests.get(url)
+response.raise_for_status()
+df = pd.read_csv(StringIO(response.text), sep="\t")
+
+
+fig, axs = plt.subplots(1, 3, figsize=(18, 6), sharex=True, sharey=True)
+
+
+binning_levels = [(10, 10), (50, 50), (100, 100)]
+
+for ax, (num_x_bins, num_y_bins) in zip(axs, binning_levels):
+    
+    df.plot(
+        kind="peakmap",
+        x="RT",
+        y="mz",
+        z="inty",
+        aggregate_duplicates=True,
+        num_x_bins=num_x_bins,
+        num_y_bins=num_y_bins,
+        canvas=ax,
+        title=f"Binning: {num_x_bins} x {num_y_bins}",
+    )
+
+
+fig.suptitle("Effect of Different Binning Levels in Peak Maps", fontsize=16)
+fig.tight_layout()


### PR DESCRIPTION
Added doc on how to adapt bin size in peakmap plots based on their functionality and what was written in the file PeakMap.ipynb.

I also changed the default value of bin_peaks, showed in the parameters table from "False" to "auto" because this is written to be the default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a demonstration tool that visualizes peak maps with varying binning configurations.
  - Offers side-by-side comparisons of different binning levels to help users better understand visualization differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->