### PR TITLE
Wrong plot running gallery_scripts_templat-#79

### DIFF
--- a/docs/gallery_scripts_template/plot_spyogenes_subplots_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_spyogenes_subplots_ms_matplotlib.py
@@ -1,55 +1,57 @@
-#!/usr/bin/env python
 """
-Plots each run in its own subplot with distinct colors per ion_annotation.
-Only the last run (Run #5) shows x-axis numbers and labels, and y-axis label.
+Plot Spyogenes subplots ms_matplotlib
+=======================================
+
+Here we show how we can plot multiple chromatograms across runs together
 """
 
-import os
 import pandas as pd
 import requests
 import zipfile
+import numpy as np
 import matplotlib.pyplot as plt
 
-#### 1) Download and Unzip Data if Not Present ####
+pd.options.plotting.backend = "ms_matplotlib"
 
+###### Load Data #######
+
+# URL of the zip file
 url = "https://github.com/OpenMS/pyopenms_viz/releases/download/v0.1.3/spyogenes.zip"
 zip_filename = "spyogenes.zip"
 
-if not os.path.exists("spyogenes"):
-    try:
-        print(f"Downloading {zip_filename} from {url} ...")
-        response = requests.get(url)
-        response.raise_for_status()
-        with open(zip_filename, "wb") as out:
-            out.write(response.content)
-        print(f"Downloaded {zip_filename} successfully.")
-    except Exception as e:
-        print("Error downloading zip file:", e)
-        raise
+# Download the zip file
+try:
+    print(f"Downloading {zip_filename}...")
+    response = requests.get(url)
+    response.raise_for_status()  # Check for any HTTP errors
 
-    try:
-        with zipfile.ZipFile(zip_filename, "r") as zip_ref:
-            zip_ref.extractall()
+    # Save the zip file to the current directory
+    with open(zip_filename, "wb") as out:
+        out.write(response.content)
+    print(f"Downloaded {zip_filename} successfully.")
+except requests.RequestException as e:
+    print(f"Error downloading zip file: {e}")
+except IOError as e:
+    print(f"Error writing zip file: {e}")
+
+# Unzipping the file
+try:
+    with zipfile.ZipFile(zip_filename, "r") as zip_ref:
+        # Extract all files to the current directory
+        zip_ref.extractall()
         print("Unzipped files successfully.")
-    except Exception as e:
-        print("Error unzipping file:", e)
-        raise
-else:
-    print("Data folder 'spyogenes' already exists. Skipping download.")
+except zipfile.BadZipFile as e:
+    print(f"Error unzipping file: {e}")
 
-#### 2) Load the Chromatogram Data ####
+annotation_bounds = pd.read_csv(
+    "spyogenes/AADGQTVSGGSILYR3_manual_annotations.tsv", sep="\t"
+)  # contain annotations across all runs
+chrom_df = pd.read_csv(
+    "spyogenes/chroms_AADGQTVSGGSILYR3.tsv", sep="\t"
+)  # contains chromatogram for precursor across all runs
 
-chrom_df = pd.read_csv("spyogenes/chroms_AADGQTVSGGSILYR3.tsv", sep="\t")
-
-# If "rt" column is missing and you have "RT", rename it
-if "rt" not in chrom_df.columns and "RT" in chrom_df.columns:
-    chrom_df = chrom_df.rename(columns={"RT": "rt"})
-
-print("\nUnique run_name values in chrom_df:")
-print(chrom_df["run_name"].unique())
-
-#### 3) Define the Run Names ####
-
+##### Set Plotting Variables #####
+pd.options.plotting.backend = "ms_matplotlib"
 RUN_NAMES = [
     "Run #0 Spyogenes 0% human plasma",
     "Run #1 Spyogenes 0% human plasma",
@@ -59,56 +61,37 @@ RUN_NAMES = [
     "Run #5 Spyogenes 10% human plasma",
 ]
 
-#### 4) Create Subplots: One Per Run ####
+fig, axs = plt.subplots(len(np.unique(chrom_df["run"])), 1, figsize=(10, 15))
 
-fig, axs = plt.subplots(nrows=len(RUN_NAMES), ncols=1, figsize=(12, 18))
+# plt.close ### required for running in jupyter notebook setting
 
+# For each run fill in the axs object with the corresponding chromatogram
+plot_list = []
 for i, run in enumerate(RUN_NAMES):
     run_df = chrom_df[chrom_df["run_name"] == run]
-    
-    # Identify unique ion annotations
-    unique_ions = run_df["ion_annotation"].unique()
-    
-    # Assign a unique color to each ion annotation
-    color_map = plt.cm.get_cmap("tab10", len(unique_ions))
-    
-    # Plot each ion annotation
-    for idx, ion in enumerate(unique_ions):
-        ion_df = run_df[run_df["ion_annotation"] == ion]
-        axs[i].plot(
-            ion_df["rt"], 
-            ion_df["int"], 
-            color=color_map(idx), 
-            label=ion, 
-            linewidth=1.5
-        )
-    
-    # Set title
-    axs[i].set_title(run, fontsize=14, fontweight="bold")
+    current_bounds = annotation_bounds[annotation_bounds["run"] == run]
 
-    # Only show x-axis ticks/labels and y-axis label for the last run
-    if run == "Run #5 Spyogenes 10% human plasma":
-        axs[i].set_xlabel("Retention Time (sec)", fontsize=12)
-        axs[i].set_ylabel("Relative Intensity", fontsize=12)
-    else:
-        axs[i].set_xticklabels([])   # remove x tick labels
-        axs[i].set_xlabel("")        # remove x label
-        axs[i].set_ylabel("")        # remove y label
-
-    # Place the legend to the right, outside the plot
-    axs[i].legend(
-        title="Ion Annotation",
-        fontsize=9,
-        title_fontsize=9,
-        loc="upper left",
-        bbox_to_anchor=(1.01, 1.0),
-        borderaxespad=0
+    run_df.plot(
+        kind="chromatogram",
+        x="rt",
+        y="int",
+        grid=False,
+        by="ion_annotation",
+        title=run_df.iloc[0]["run_name"],
+        title_font_size=16,
+        xaxis_label_font_size=14,
+        yaxis_label_font_size=14,
+        xaxis_tick_font_size=12,
+        yaxis_tick_font_size=12,
+        canvas=axs[i],
+        relative_intensity=True,
+        annotation_data=current_bounds,
+        xlabel="Retention Time (sec)",
+        ylabel="Relative\nIntensity",
+        annotation_legend_config=dict(show=False),
+        legend_config={"show": False},
+        show_plot=False,
     )
 
-# Adjust spacing
-plt.subplots_adjust(hspace=0.4, right=0.8)
-
-# Optional main title
-fig.suptitle("Spyogenes Chromatograms Across Runs", fontsize=16, fontweight="bold")
-
-plt.show()
+fig.tight_layout()
+fig.show()

--- a/docs/gallery_scripts_template/plot_spyogenes_subplots_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_spyogenes_subplots_ms_matplotlib.py
@@ -1,57 +1,55 @@
+#!/usr/bin/env python
 """
-Plot Spyogenes subplots ms_matplotlib
-=======================================
-
-Here we show how we can plot multiple chromatograms across runs together
+Plots each run in its own subplot with distinct colors per ion_annotation.
+Only the last run (Run #5) shows x-axis numbers and labels, and y-axis label.
 """
 
+import os
 import pandas as pd
 import requests
 import zipfile
-import numpy as np
 import matplotlib.pyplot as plt
 
-pd.options.plotting.backend = "ms_matplotlib"
+#### 1) Download and Unzip Data if Not Present ####
 
-###### Load Data #######
-
-# URL of the zip file
 url = "https://github.com/OpenMS/pyopenms_viz/releases/download/v0.1.3/spyogenes.zip"
 zip_filename = "spyogenes.zip"
 
-# Download the zip file
-try:
-    print(f"Downloading {zip_filename}...")
-    response = requests.get(url)
-    response.raise_for_status()  # Check for any HTTP errors
+if not os.path.exists("spyogenes"):
+    try:
+        print(f"Downloading {zip_filename} from {url} ...")
+        response = requests.get(url)
+        response.raise_for_status()
+        with open(zip_filename, "wb") as out:
+            out.write(response.content)
+        print(f"Downloaded {zip_filename} successfully.")
+    except Exception as e:
+        print("Error downloading zip file:", e)
+        raise
 
-    # Save the zip file to the current directory
-    with open(zip_filename, "wb") as out:
-        out.write(response.content)
-    print(f"Downloaded {zip_filename} successfully.")
-except requests.RequestException as e:
-    print(f"Error downloading zip file: {e}")
-except IOError as e:
-    print(f"Error writing zip file: {e}")
-
-# Unzipping the file
-try:
-    with zipfile.ZipFile(zip_filename, "r") as zip_ref:
-        # Extract all files to the current directory
-        zip_ref.extractall()
+    try:
+        with zipfile.ZipFile(zip_filename, "r") as zip_ref:
+            zip_ref.extractall()
         print("Unzipped files successfully.")
-except zipfile.BadZipFile as e:
-    print(f"Error unzipping file: {e}")
+    except Exception as e:
+        print("Error unzipping file:", e)
+        raise
+else:
+    print("Data folder 'spyogenes' already exists. Skipping download.")
 
-annotation_bounds = pd.read_csv(
-    "spyogenes/AADGQTVSGGSILYR3_manual_annotations.tsv", sep="\t"
-)  # contain annotations across all runs
-chrom_df = pd.read_csv(
-    "spyogenes/chroms_AADGQTVSGGSILYR3.tsv", sep="\t"
-)  # contains chromatogram for precursor across all runs
+#### 2) Load the Chromatogram Data ####
 
-##### Set Plotting Variables #####
-pd.options.plotting.backend = "ms_matplotlib"
+chrom_df = pd.read_csv("spyogenes/chroms_AADGQTVSGGSILYR3.tsv", sep="\t")
+
+# If "rt" column is missing and you have "RT", rename it
+if "rt" not in chrom_df.columns and "RT" in chrom_df.columns:
+    chrom_df = chrom_df.rename(columns={"RT": "rt"})
+
+print("\nUnique run_name values in chrom_df:")
+print(chrom_df["run_name"].unique())
+
+#### 3) Define the Run Names ####
+
 RUN_NAMES = [
     "Run #0 Spyogenes 0% human plasma",
     "Run #1 Spyogenes 0% human plasma",
@@ -61,36 +59,56 @@ RUN_NAMES = [
     "Run #5 Spyogenes 10% human plasma",
 ]
 
-fig, axs = plt.subplots(len(np.unique(chrom_df["run"])), 1, figsize=(10, 15))
+#### 4) Create Subplots: One Per Run ####
 
-# plt.close ### required for running in jupyter notebook setting
+fig, axs = plt.subplots(nrows=len(RUN_NAMES), ncols=1, figsize=(12, 18))
 
-# For each run fill in the axs object with the corresponding chromatogram
-plot_list = []
 for i, run in enumerate(RUN_NAMES):
     run_df = chrom_df[chrom_df["run_name"] == run]
-    current_bounds = annotation_bounds[annotation_bounds["run"] == run]
+    
+    # Identify unique ion annotations
+    unique_ions = run_df["ion_annotation"].unique()
+    
+    # Assign a unique color to each ion annotation
+    color_map = plt.cm.get_cmap("tab10", len(unique_ions))
+    
+    # Plot each ion annotation
+    for idx, ion in enumerate(unique_ions):
+        ion_df = run_df[run_df["ion_annotation"] == ion]
+        axs[i].plot(
+            ion_df["rt"], 
+            ion_df["int"], 
+            color=color_map(idx), 
+            label=ion, 
+            linewidth=1.5
+        )
+    
+    # Set title
+    axs[i].set_title(run, fontsize=14, fontweight="bold")
 
-    run_df.plot(
-        kind="chromatogram",
-        x="rt",
-        y="int",
-        grid=False,
-        by="ion_annotation",
-        title=run_df.iloc[0]["run_name"],
-        title_font_size=16,
-        xaxis_label_font_size=14,
-        yaxis_label_font_size=14,
-        xaxis_tick_font_size=12,
-        yaxis_tick_font_size=12,
-        canvas=axs[i],
-        relative_intensity=True,
-        annotation_data=current_bounds,
-        xlabel="Retention Time (sec)",
-        ylabel="Relative\nIntensity",
-        annotation_legend_config=dict(show=False),
-        legend_config={"show": False},
+    # Only show x-axis ticks/labels and y-axis label for the last run
+    if run == "Run #5 Spyogenes 10% human plasma":
+        axs[i].set_xlabel("Retention Time (sec)", fontsize=12)
+        axs[i].set_ylabel("Relative Intensity", fontsize=12)
+    else:
+        axs[i].set_xticklabels([])   # remove x tick labels
+        axs[i].set_xlabel("")        # remove x label
+        axs[i].set_ylabel("")        # remove y label
+
+    # Place the legend to the right, outside the plot
+    axs[i].legend(
+        title="Ion Annotation",
+        fontsize=9,
+        title_fontsize=9,
+        loc="upper left",
+        bbox_to_anchor=(1.01, 1.0),
+        borderaxespad=0
     )
 
-fig.tight_layout()
-fig
+# Adjust spacing
+plt.subplots_adjust(hspace=0.4, right=0.8)
+
+# Optional main title
+fig.suptitle("Spyogenes Chromatograms Across Runs", fontsize=16, fontweight="bold")
+
+plt.show()


### PR DESCRIPTION
![Screenshot 2025-03-21 003117](https://github.com/user-attachments/assets/3e0a5d9e-e694-4c83-ac08-4532074496bc)
# Issue: Only the First Subplot Filled

## How I Fixed It
Instead of passing canvas=axs[i] (which only worked for the first subplot with ms_matplotlib), I switched to standard Matplotlib subplots and explicitly plotted each run. I also color-coded each ion annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced control over plotting behavior with the addition of a parameter to control immediate display of plots.

- **Refactor**
	- Streamlined data preparation with pre-download checks and unified error handling.
	- Optimized plot layout with an external legend and optional main title for a cleaner visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->