### PR TITLE
Improve-spectrum-binning-subplot-display

### DIFF
--- a/docs/gallery_scripts_template/plot_investigate_spectrum_binning_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_investigate_spectrum_binning_ms_matplotlib.py
@@ -1,8 +1,8 @@
 """
-Investigate Spctrum Binning ms_matplotlib
-=======================================
+Investigate Spectrum Binning ms_matplotlib
+===========================================
 
-Here we use a dummy spectrum example to investigate spectrum binning. 
+Here we use a dummy spectrum example to investigate spectrum binning.
 """
 
 import pandas as pd
@@ -10,9 +10,10 @@ import matplotlib.pyplot as plt
 import requests
 from io import StringIO
 
+# Set the plotting backend
 pd.options.plotting.backend = "ms_matplotlib"
 
-# download the file for example plotting
+# Download the file for example plotting
 url = (
     "https://github.com/OpenMS/pyopenms_viz/releases/download/v0.1.5/TestSpectrumDf.tsv"
 )
@@ -20,7 +21,7 @@ response = requests.get(url)
 response.raise_for_status()  # Check for any HTTP errors
 df = pd.read_csv(StringIO(response.text), sep="\t")
 
-# Let's assess the peak binning and create a 4 by 2 subplot to visualize the different methods of binning
+# Define different parameters for spectrum binning visualization
 params_list = [
     {"title": "Spectrum (Raw)", "bin_peaks": False},
     {
@@ -72,18 +73,26 @@ params_list = [
     },
 ]
 
-# Create a 3-row subplot
+# Create a 4x2 subplot layout for the different binning methods
 fig, axs = plt.subplots(4, 2, figsize=(14, 14))
 
 i = j = 0
 for params in params_list:
-    p = df.plot(
-        kind="spectrum", x="mz", y="intensity", canvas=axs[i][j], grid=False, **params
+    df.plot(
+        kind="spectrum",
+        x="mz",
+        y="intensity",
+        canvas=axs[i][j],
+        grid=False,
+        show_plot=False,
+        **params
     )
     j += 1
-    if j >= 2:  # If we've filled two columns, move to the next row
+    if j >= 2:
         j = 0
         i += 1
 
 fig.tight_layout()
-fig.show()
+
+# Use plt.show() to display the figure and manage the event loop properly.
+plt.show()

--- a/docs/gallery_scripts_template/plot_investigate_spectrum_binning_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_investigate_spectrum_binning_ms_matplotlib.py
@@ -1,8 +1,8 @@
 """
-Investigate Spectrum Binning ms_matplotlib
-===========================================
+Investigate Spctrum Binning ms_matplotlib
+=======================================
 
-Here we use a dummy spectrum example to investigate spectrum binning.
+Here we use a dummy spectrum example to investigate spectrum binning. 
 """
 
 import pandas as pd
@@ -10,10 +10,9 @@ import matplotlib.pyplot as plt
 import requests
 from io import StringIO
 
-# Set the plotting backend
 pd.options.plotting.backend = "ms_matplotlib"
 
-# Download the file for example plotting
+# download the file for example plotting
 url = (
     "https://github.com/OpenMS/pyopenms_viz/releases/download/v0.1.5/TestSpectrumDf.tsv"
 )
@@ -21,7 +20,7 @@ response = requests.get(url)
 response.raise_for_status()  # Check for any HTTP errors
 df = pd.read_csv(StringIO(response.text), sep="\t")
 
-# Define different parameters for spectrum binning visualization
+# Let's assess the peak binning and create a 4 by 2 subplot to visualize the different methods of binning
 params_list = [
     {"title": "Spectrum (Raw)", "bin_peaks": False},
     {
@@ -73,26 +72,18 @@ params_list = [
     },
 ]
 
-# Create a 4x2 subplot layout for the different binning methods
+# Create a 3-row subplot
 fig, axs = plt.subplots(4, 2, figsize=(14, 14))
 
 i = j = 0
 for params in params_list:
-    df.plot(
-        kind="spectrum",
-        x="mz",
-        y="intensity",
-        canvas=axs[i][j],
-        grid=False,
-        show_plot=False,
-        **params
+    p = df.plot(
+        kind="spectrum", x="mz", y="intensity", canvas=axs[i][j], grid=False, show_plot=False, **params
     )
     j += 1
-    if j >= 2:
+    if j >= 2:  # If we've filled two columns, move to the next row
         j = 0
         i += 1
 
 fig.tight_layout()
-
-# Use plt.show() to display the figure and manage the event loop properly.
 plt.show()


### PR DESCRIPTION
# Spectrum Binning Visualization Enhancement

This pull request refines the spectrum binning visualization process using a dummy spectrum example. It demonstrates various binning strategies while improving subplot management and display.

## Overview

- **Backend Update:** Sets `ms_matplotlib` as the plotting backend for consistent visualization.
- **Binning Methods:** Implements a range of binning techniques including raw, aggregated (sum, mean, max), and specific strategies like `freedman-diaconis` and `mz-tol-bin` with configurable parameters.
- **Subplot Management:** Refactors subplot creation into a 4x2 layout, using `plt.show()` with `show_plot=False` for better event loop handling and display.

## Changes Made

- Configured the plotting backend to `ms_matplotlib`.
- Downloaded a test dataset from GitHub for example plotting.
- Defined multiple spectrum binning parameters for side-by-side comparison.
- Replaced `fig.show()` with `plt.show()` to properly manage the display of the subplots.
- Improved code clarity with enhanced inline comments.

![Uploading Screenshot 2025-03-22 160408.png…]()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an option to disable automatic plot display, giving users more control over when plots are rendered.

- **Bug Fixes**
  - Improved consistency in the plot display method for better rendering with the matplotlib library.

- **Documentation**
  - Corrected a title typo and improved descriptive text.
  - Updated layout descriptions and comment formatting for enhanced clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->