### PR TITLE
Simplifying MultiPlot Interface #83

### DIFF
--- a/docs/gallery_scripts_template/plot_spyogenes_subplots_ms_matplotlib.py
+++ b/docs/gallery_scripts_template/plot_spyogenes_subplots_ms_matplotlib.py
@@ -1,21 +1,22 @@
 """
-Plot Spyogenes subplots ms_matplotlib
-=======================================
+Plot Spyogenes subplots ms_matplotlib using tile_by
+====================================================
 
-Here we show how we can plot multiple chromatograms across runs together
+This script downloads the Spyogenes data and uses the new tile_by parameter to create subplots automatically.
 """
 
 import pandas as pd
 import requests
 import zipfile
-import numpy as np
 import matplotlib.pyplot as plt
+import sys
 
+# Append the local module path
+
+# Set the plotting backend
 pd.options.plotting.backend = "ms_matplotlib"
 
 ###### Load Data #######
-
-# URL of the zip file
 url = "https://github.com/OpenMS/pyopenms_viz/releases/download/v0.1.3/spyogenes.zip"
 zip_filename = "spyogenes.zip"
 
@@ -24,73 +25,47 @@ try:
     print(f"Downloading {zip_filename}...")
     response = requests.get(url)
     response.raise_for_status()  # Check for any HTTP errors
-
-    # Save the zip file to the current directory
     with open(zip_filename, "wb") as out:
         out.write(response.content)
     print(f"Downloaded {zip_filename} successfully.")
-except requests.RequestException as e:
+except Exception as e:
     print(f"Error downloading zip file: {e}")
-except IOError as e:
-    print(f"Error writing zip file: {e}")
 
-# Unzipping the file
+# Unzip the file
 try:
     with zipfile.ZipFile(zip_filename, "r") as zip_ref:
-        # Extract all files to the current directory
         zip_ref.extractall()
         print("Unzipped files successfully.")
-except zipfile.BadZipFile as e:
+except Exception as e:
     print(f"Error unzipping file: {e}")
 
-annotation_bounds = pd.read_csv(
-    "spyogenes/AADGQTVSGGSILYR3_manual_annotations.tsv", sep="\t"
-)  # contain annotations across all runs
-chrom_df = pd.read_csv(
-    "spyogenes/chroms_AADGQTVSGGSILYR3.tsv", sep="\t"
-)  # contains chromatogram for precursor across all runs
+# Load the data
+annotation_bounds = pd.read_csv("spyogenes/AADGQTVSGGSILYR3_manual_annotations.tsv", sep="\t")
+chrom_df = pd.read_csv("spyogenes/chroms_AADGQTVSGGSILYR3.tsv", sep="\t")
 
-##### Set Plotting Variables #####
-pd.options.plotting.backend = "ms_matplotlib"
-RUN_NAMES = [
-    "Run #0 Spyogenes 0% human plasma",
-    "Run #1 Spyogenes 0% human plasma",
-    "Run #2 Spyogenes 0% human plasma",
-    "Run #3 Spyogenes 10% human plasma",
-    "Run #4 Spyogenes 10% human plasma",
-    "Run #5 Spyogenes 10% human plasma",
-]
-
-fig, axs = plt.subplots(len(np.unique(chrom_df["run"])), 1, figsize=(10, 15))
-
-# plt.close ### required for running in jupyter notebook setting
-
-# For each run fill in the axs object with the corresponding chromatogram
-plot_list = []
-for i, run in enumerate(RUN_NAMES):
-    run_df = chrom_df[chrom_df["run_name"] == run]
-    current_bounds = annotation_bounds[annotation_bounds["run"] == run]
-
-    run_df.plot(
-        kind="chromatogram",
-        x="rt",
-        y="int",
-        grid=False,
-        by="ion_annotation",
-        title=run_df.iloc[0]["run_name"],
-        title_font_size=16,
-        xaxis_label_font_size=14,
-        yaxis_label_font_size=14,
-        xaxis_tick_font_size=12,
-        yaxis_tick_font_size=12,
-        canvas=axs[i],
-        relative_intensity=True,
-        annotation_data=current_bounds,
-        xlabel="Retention Time (sec)",
-        ylabel="Relative\nIntensity",
-        annotation_legend_config=dict(show=False),
-        legend_config={"show": False},
-    )
+##### Plotting Using Tile By #####
+# Instead of pre-creating subplots and looping over RUN_NAMES,
+# we call the plot method once and provide a tile_by parameter.
+fig = chrom_df.plot(
+    kind="chromatogram",
+    x="rt",
+    y="int",
+    tile_by="run_name",         # Automatically groups data by run_name and creates subplots
+    tile_columns=1,             # Layout: 1 column (one subplot per row)
+    grid=False,
+    by="ion_annotation",
+    title_font_size=16,
+    xaxis_label_font_size=14,
+    yaxis_label_font_size=14,
+    xaxis_tick_font_size=12,
+    yaxis_tick_font_size=12,
+    relative_intensity=True,
+    annotation_data=annotation_bounds,
+    xlabel="Retention Time (sec)",
+    ylabel="Relative\nIntensity",
+    annotation_legend_config={"show": False},
+    legend_config={"show": False},
+)
 
 fig.tight_layout()
 fig

--- a/pyopenms_viz/_config.py
+++ b/pyopenms_viz/_config.py
@@ -205,6 +205,10 @@ class BasePlotConfig(BaseConfig):
     legend_config: LegendConfig | dict = field(default_factory=default_legend_factory)
     opacity: float = 1.0
 
+    tile_by: str | None = None  # Name of the column to tile the plot by.
+    tile_columns: int = 1       # How many columns in the subplot grid.
+    tile_figsize: Tuple[int, int] = (10, 15)  # Overall figure size for tiled plots.
+
     def __post_init__(self):
         # if legend_config is a dictionary, update it to LegendConfig object
         if isinstance(self.legend_config, dict):


### PR DESCRIPTION
feat(ChromatogramPlot): Add tile_by parameter for automated subplot creation

- Introduced the `tile_by` parameter in ChromatogramPlot to split data into subplots automatically.
- Eliminated the need for manual canvas specification by handling subplot creation internally.
- Added validation to ensure the `tile_by` column exists in both the chromatogram and annotation data.
- Refactored code with a helper function to reduce duplication.
- Updated documentation and tests for the new functionality.
