### PR TITLE
feat: add Polars support with version-locked dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ docs/generated
 docs/gallery_scripts
 docs/_build
 .DS_Store
+venv/
+.venv/
+_build/
+tmpclaude-c0db-cwd

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pyOpenMS-Viz is a Python library that provides a simple interface for extending 
 
 
 ### Note on Polars DataFrames
-`pyopenms_viz` fully supports [Polars](https://pola.rs/) DataFrames via an Arrow-backed zero-copy conversion. However, due to API differences, you must use the `.ms_plot()` namespace instead of `.plot()` when working with Polars.
+`pyopenms_viz` can work with [Polars](https://pola.rs/) DataFrames by internally converting them to pandas, often via an Arrow-backed representation where possible. This conversion may involve data copies depending on data types and configuration, and plotting is ultimately delegated to the pandas-based plotting backends. Due to API differences, you must use the `.ms_plot()` namespace instead of `.plot()` when working with Polars.
 
 **Pandas:**
 ```python

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ pyOpenMS-Viz is a Python library that provides a simple interface for extending 
 | PeakMap 3D      | x, y, z                 | peakmap (plot3d=True)                                     | ✓              |           | ✓          |
 
 
+### Note on Polars DataFrames
+`pyopenms_viz` fully supports [Polars](https://pola.rs/) DataFrames via an Arrow-backed zero-copy conversion. However, due to API differences, you must use the `.ms_plot()` namespace instead of `.plot()` when working with Polars.
+
+**Pandas:**
+```python
+df_pandas.plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly")
+```
+
+**Polars:**
+```python
+df_polars.ms_plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly")
+```
+
 ## (Recommended) Pip Installation
 
 The recommended way of installing pyopenms_viz is through the Python Package Index (PyPI). We recommend installing pyopenms_viz in its own virtual environment using Anaconda to avoid packaging conflicts.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -312,7 +312,8 @@ sphinx_gallery_conf = {
     "binder": {
         "org": "OpenMS",
         "repo": "pyopenms_viz",
-        "branch": "gh_pages",
+        # Use the source branch for Binder launches; gh_pages is a deploy artifact branch.
+        "branch": "main",
         "binderhub_url": "https://notebooks.gesis.org/binder",
         "dependencies": "./requirements.txt",
     },

--- a/pyopenms_viz/__init__.py
+++ b/pyopenms_viz/__init__.py
@@ -1,7 +1,7 @@
 """
 init
 """
-from . import _polars_accessor
+from . import _polars_accessor  # Import for side effects: registers pandas accessors. noqa: F401
 from pandas.plotting._core import PlotAccessor
 from pandas.core.frame import DataFrame
 from typing import Any

--- a/pyopenms_viz/__init__.py
+++ b/pyopenms_viz/__init__.py
@@ -1,7 +1,7 @@
 """
 init
 """
-
+from . import _polars_accessor
 from pandas.plotting._core import PlotAccessor
 from pandas.core.frame import DataFrame
 from typing import Any

--- a/pyopenms_viz/_polars_accessor.py
+++ b/pyopenms_viz/_polars_accessor.py
@@ -1,0 +1,25 @@
+"""
+Polars namespace extension for pyopenms_viz.
+Provides a thin wrapper to bridge Polars DataFrames with the existing 
+Pandas-based plotting architecture.
+"""
+import warnings
+
+try:
+    import polars as pl
+    POLARS_AVAILABLE = True
+except ImportError:
+    POLARS_AVAILABLE = False
+
+if POLARS_AVAILABLE:
+    @pl.api.register_dataframe_namespace("ms_plot")
+    class PolarsPlotAccessor:
+        """
+        Registers the '.ms_plot' namespace for Polars DataFrames.
+        """
+        def __init__(self, df: pl.DataFrame):
+            self._df = df
+
+        def __call__(self, *args, **kwargs):
+            pandas_df = self._df.to_pandas()
+            return pandas_df.plot(*args, **kwargs)

--- a/pyopenms_viz/_polars_accessor.py
+++ b/pyopenms_viz/_polars_accessor.py
@@ -3,8 +3,6 @@ Polars namespace extension for pyopenms_viz.
 Provides a thin wrapper to bridge Polars DataFrames with the existing 
 Pandas-based plotting architecture.
 """
-import warnings
-
 try:
     import polars as pl
     POLARS_AVAILABLE = True
@@ -21,5 +19,9 @@ if POLARS_AVAILABLE:
             self._df = df
 
         def __call__(self, *args, **kwargs):
-            pandas_df = self._df.to_pandas()
+            # Convert to Pandas using Arrow-backed extension arrays for 
+            # better performance and null handling 
+            pandas_df = self._df.to_pandas(use_pyarrow_extension_array=True)
+            
+            # Delegate to Pandas' native plot method
             return pandas_df.plot(*args, **kwargs)

--- a/pyopenms_viz/_polars_accessor.py
+++ b/pyopenms_viz/_polars_accessor.py
@@ -16,16 +16,15 @@ if POLARS_AVAILABLE:
         def __call__(self, *args, **kwargs):
             try:
                 # 1. Safety Catch: Use Arrow-backed arrays with a clear error fallback
-                # This prevents cryptic crashes if pyarrow is missing.
                 pandas_df = self._df.to_pandas(use_pyarrow_extension_array=True)
             except (ImportError, ModuleNotFoundError) as exc:
-                raise RuntimeError(
+                raise ImportError(
                     "Converting a Polars DataFrame to pandas failed because required "
                     "optional dependencies are missing. Please install 'pyarrow':\n"
                     "  pip install pyarrow"
                 ) from exc
             
-            # 2. Correct Routing: Use the library's internal PlotAccessor.
-            # This ensures custom backends like 'ms_plotly' are found automatically.
-            from pyopenms_viz._core import PlotAccessor
-            return PlotAccessor(pandas_df)(*args, **kwargs)
+            # 2. Delegate to pandas' plotting API.
+            # This lets pandas resolve ms_* backends via entry points and respect
+            # the global `pd.options.plotting.backend` setting.
+            return pandas_df.plot(*args, **kwargs)

--- a/pyopenms_viz/_polars_accessor.py
+++ b/pyopenms_viz/_polars_accessor.py
@@ -1,7 +1,5 @@
 """
 Polars namespace extension for pyopenms_viz.
-Provides a thin wrapper to bridge Polars DataFrames with the existing 
-Pandas-based plotting architecture.
 """
 try:
     import polars as pl
@@ -12,16 +10,22 @@ except ImportError:
 if POLARS_AVAILABLE:
     @pl.api.register_dataframe_namespace("ms_plot")
     class PolarsPlotAccessor:
-        """
-        Registers the '.ms_plot' namespace for Polars DataFrames.
-        """
         def __init__(self, df: pl.DataFrame):
             self._df = df
 
         def __call__(self, *args, **kwargs):
-            # Convert to Pandas using Arrow-backed extension arrays for 
-            # better performance and null handling 
-            pandas_df = self._df.to_pandas(use_pyarrow_extension_array=True)
+            try:
+                # 1. Safety Catch: Use Arrow-backed arrays with a clear error fallback
+                # This prevents cryptic crashes if pyarrow is missing.
+                pandas_df = self._df.to_pandas(use_pyarrow_extension_array=True)
+            except (ImportError, ModuleNotFoundError) as exc:
+                raise RuntimeError(
+                    "Converting a Polars DataFrame to pandas failed because required "
+                    "optional dependencies are missing. Please install 'pyarrow':\n"
+                    "  pip install pyarrow"
+                ) from exc
             
-            # Delegate to Pandas' native plot method
-            return pandas_df.plot(*args, **kwargs)
+            # 2. Correct Routing: Use the library's internal PlotAccessor.
+            # This ensures custom backends like 'ms_plotly' are found automatically.
+            from pyopenms_viz._core import PlotAccessor
+            return PlotAccessor(pandas_df)(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -307,3 +307,5 @@ webencodings==0.5.1
     #   tinycss2
 xyzservices==2025.11.0
     # via bokeh
+polars==1.38.1
+pyarrow==23.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -177,6 +177,8 @@ plotly==5.24.1
     # via pyopenms_viz (pyproject.toml)
 pluggy==1.6.0
     # via pytest
+polars==1.38.1
+
 prompt-toolkit==3.0.52
     # via ipython
 psutil==7.2.2
@@ -185,6 +187,8 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
+pyarrow==23.0.1
+    # via polars
 pycparser==3.0
     # via cffi
 pydata-sphinx-theme==0.16.1
@@ -215,6 +219,7 @@ pytz==2025.2
     # via pandas
 pyyaml==6.0.3
     # via bokeh
+    
 pyzmq==27.1.0
     # via
     #   ipykernel
@@ -307,5 +312,4 @@ webencodings==0.5.1
     #   tinycss2
 xyzservices==2025.11.0
     # via bokeh
-polars==1.38.1
-pyarrow==23.0.1
+

--- a/test/__snapshots__/test_polars_accessor/test_polars_ms_plot_snapshot.json
+++ b/test/__snapshots__/test_polars_accessor/test_polars_ms_plot_snapshot.json
@@ -1,0 +1,1090 @@
+{
+  "data": [
+    {
+      "line": {
+        "color": "#4575B4"
+      },
+      "mode": "lines",
+      "x": [
+        100.1,
+        100.1,
+        100.1,
+        100.2,
+        100.2,
+        100.2,
+        105.0,
+        105.0,
+        105.0,
+        105.1,
+        105.1,
+        105.1
+      ],
+      "y": [
+        0.0,
+        10.0,
+        0.0,
+        0.0,
+        50.0,
+        0.0,
+        0.0,
+        100.0,
+        0.0,
+        0.0,
+        90.0,
+        0.0
+      ],
+      "type": "scatter",
+      "customdata": [
+        [
+          100.1,
+          10.0
+        ],
+        [
+          100.1,
+          10.0
+        ],
+        [
+          100.1,
+          10.0
+        ],
+        [
+          100.2,
+          50.0
+        ],
+        [
+          100.2,
+          50.0
+        ],
+        [
+          100.2,
+          50.0
+        ],
+        [
+          105.0,
+          100.0
+        ],
+        [
+          105.0,
+          100.0
+        ],
+        [
+          105.0,
+          100.0
+        ],
+        [
+          105.1,
+          90.0
+        ],
+        [
+          105.1,
+          90.0
+        ],
+        [
+          105.1,
+          90.0
+        ]
+      ],
+      "hovertemplate": "m\u002fz: %{customdata[0]}\u003cbr\u003eintensity: %{customdata[1]}"
+    }
+  ],
+  "layout": {
+    "template": {
+      "data": {
+        "barpolar": [
+          {
+            "marker": {
+              "line": {
+                "color": "white",
+                "width": 0.5
+              },
+              "pattern": {
+                "fillmode": "overlay",
+                "size": 10,
+                "solidity": 0.2
+              }
+            },
+            "type": "barpolar"
+          }
+        ],
+        "bar": [
+          {
+            "error_x": {
+              "color": "rgb(36,36,36)"
+            },
+            "error_y": {
+              "color": "rgb(36,36,36)"
+            },
+            "marker": {
+              "line": {
+                "color": "white",
+                "width": 0.5
+              },
+              "pattern": {
+                "fillmode": "overlay",
+                "size": 10,
+                "solidity": 0.2
+              }
+            },
+            "type": "bar"
+          }
+        ],
+        "carpet": [
+          {
+            "aaxis": {
+              "endlinecolor": "rgb(36,36,36)",
+              "gridcolor": "white",
+              "linecolor": "white",
+              "minorgridcolor": "white",
+              "startlinecolor": "rgb(36,36,36)"
+            },
+            "baxis": {
+              "endlinecolor": "rgb(36,36,36)",
+              "gridcolor": "white",
+              "linecolor": "white",
+              "minorgridcolor": "white",
+              "startlinecolor": "rgb(36,36,36)"
+            },
+            "type": "carpet"
+          }
+        ],
+        "choropleth": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "type": "choropleth"
+          }
+        ],
+        "contourcarpet": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "type": "contourcarpet"
+          }
+        ],
+        "contour": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "colorscale": [
+              [
+                0.0,
+                "#440154"
+              ],
+              [
+                0.1111111111111111,
+                "#482878"
+              ],
+              [
+                0.2222222222222222,
+                "#3e4989"
+              ],
+              [
+                0.3333333333333333,
+                "#31688e"
+              ],
+              [
+                0.4444444444444444,
+                "#26828e"
+              ],
+              [
+                0.5555555555555556,
+                "#1f9e89"
+              ],
+              [
+                0.6666666666666666,
+                "#35b779"
+              ],
+              [
+                0.7777777777777778,
+                "#6ece58"
+              ],
+              [
+                0.8888888888888888,
+                "#b5de2b"
+              ],
+              [
+                1.0,
+                "#fde725"
+              ]
+            ],
+            "type": "contour"
+          }
+        ],
+        "heatmapgl": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "colorscale": [
+              [
+                0.0,
+                "#440154"
+              ],
+              [
+                0.1111111111111111,
+                "#482878"
+              ],
+              [
+                0.2222222222222222,
+                "#3e4989"
+              ],
+              [
+                0.3333333333333333,
+                "#31688e"
+              ],
+              [
+                0.4444444444444444,
+                "#26828e"
+              ],
+              [
+                0.5555555555555556,
+                "#1f9e89"
+              ],
+              [
+                0.6666666666666666,
+                "#35b779"
+              ],
+              [
+                0.7777777777777778,
+                "#6ece58"
+              ],
+              [
+                0.8888888888888888,
+                "#b5de2b"
+              ],
+              [
+                1.0,
+                "#fde725"
+              ]
+            ],
+            "type": "heatmapgl"
+          }
+        ],
+        "heatmap": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "colorscale": [
+              [
+                0.0,
+                "#440154"
+              ],
+              [
+                0.1111111111111111,
+                "#482878"
+              ],
+              [
+                0.2222222222222222,
+                "#3e4989"
+              ],
+              [
+                0.3333333333333333,
+                "#31688e"
+              ],
+              [
+                0.4444444444444444,
+                "#26828e"
+              ],
+              [
+                0.5555555555555556,
+                "#1f9e89"
+              ],
+              [
+                0.6666666666666666,
+                "#35b779"
+              ],
+              [
+                0.7777777777777778,
+                "#6ece58"
+              ],
+              [
+                0.8888888888888888,
+                "#b5de2b"
+              ],
+              [
+                1.0,
+                "#fde725"
+              ]
+            ],
+            "type": "heatmap"
+          }
+        ],
+        "histogram2dcontour": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "colorscale": [
+              [
+                0.0,
+                "#440154"
+              ],
+              [
+                0.1111111111111111,
+                "#482878"
+              ],
+              [
+                0.2222222222222222,
+                "#3e4989"
+              ],
+              [
+                0.3333333333333333,
+                "#31688e"
+              ],
+              [
+                0.4444444444444444,
+                "#26828e"
+              ],
+              [
+                0.5555555555555556,
+                "#1f9e89"
+              ],
+              [
+                0.6666666666666666,
+                "#35b779"
+              ],
+              [
+                0.7777777777777778,
+                "#6ece58"
+              ],
+              [
+                0.8888888888888888,
+                "#b5de2b"
+              ],
+              [
+                1.0,
+                "#fde725"
+              ]
+            ],
+            "type": "histogram2dcontour"
+          }
+        ],
+        "histogram2d": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "colorscale": [
+              [
+                0.0,
+                "#440154"
+              ],
+              [
+                0.1111111111111111,
+                "#482878"
+              ],
+              [
+                0.2222222222222222,
+                "#3e4989"
+              ],
+              [
+                0.3333333333333333,
+                "#31688e"
+              ],
+              [
+                0.4444444444444444,
+                "#26828e"
+              ],
+              [
+                0.5555555555555556,
+                "#1f9e89"
+              ],
+              [
+                0.6666666666666666,
+                "#35b779"
+              ],
+              [
+                0.7777777777777778,
+                "#6ece58"
+              ],
+              [
+                0.8888888888888888,
+                "#b5de2b"
+              ],
+              [
+                1.0,
+                "#fde725"
+              ]
+            ],
+            "type": "histogram2d"
+          }
+        ],
+        "histogram": [
+          {
+            "marker": {
+              "line": {
+                "color": "white",
+                "width": 0.6
+              }
+            },
+            "type": "histogram"
+          }
+        ],
+        "mesh3d": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "type": "mesh3d"
+          }
+        ],
+        "parcoords": [
+          {
+            "line": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "parcoords"
+          }
+        ],
+        "pie": [
+          {
+            "automargin": true,
+            "type": "pie"
+          }
+        ],
+        "scatter3d": [
+          {
+            "line": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scatter3d"
+          }
+        ],
+        "scattercarpet": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scattercarpet"
+          }
+        ],
+        "scattergeo": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scattergeo"
+          }
+        ],
+        "scattergl": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scattergl"
+          }
+        ],
+        "scattermapbox": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scattermapbox"
+          }
+        ],
+        "scatterpolargl": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scatterpolargl"
+          }
+        ],
+        "scatterpolar": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scatterpolar"
+          }
+        ],
+        "scatter": [
+          {
+            "fillpattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+            },
+            "type": "scatter"
+          }
+        ],
+        "scatterternary": [
+          {
+            "marker": {
+              "colorbar": {
+                "outlinewidth": 1,
+                "tickcolor": "rgb(36,36,36)",
+                "ticks": "outside"
+              }
+            },
+            "type": "scatterternary"
+          }
+        ],
+        "surface": [
+          {
+            "colorbar": {
+              "outlinewidth": 1,
+              "tickcolor": "rgb(36,36,36)",
+              "ticks": "outside"
+            },
+            "colorscale": [
+              [
+                0.0,
+                "#440154"
+              ],
+              [
+                0.1111111111111111,
+                "#482878"
+              ],
+              [
+                0.2222222222222222,
+                "#3e4989"
+              ],
+              [
+                0.3333333333333333,
+                "#31688e"
+              ],
+              [
+                0.4444444444444444,
+                "#26828e"
+              ],
+              [
+                0.5555555555555556,
+                "#1f9e89"
+              ],
+              [
+                0.6666666666666666,
+                "#35b779"
+              ],
+              [
+                0.7777777777777778,
+                "#6ece58"
+              ],
+              [
+                0.8888888888888888,
+                "#b5de2b"
+              ],
+              [
+                1.0,
+                "#fde725"
+              ]
+            ],
+            "type": "surface"
+          }
+        ],
+        "table": [
+          {
+            "cells": {
+              "fill": {
+                "color": "rgb(237,237,237)"
+              },
+              "line": {
+                "color": "white"
+              }
+            },
+            "header": {
+              "fill": {
+                "color": "rgb(217,217,217)"
+              },
+              "line": {
+                "color": "white"
+              }
+            },
+            "type": "table"
+          }
+        ]
+      },
+      "layout": {
+        "annotationdefaults": {
+          "arrowhead": 0,
+          "arrowwidth": 1
+        },
+        "autotypenumbers": "strict",
+        "coloraxis": {
+          "colorbar": {
+            "outlinewidth": 1,
+            "tickcolor": "rgb(36,36,36)",
+            "ticks": "outside"
+          }
+        },
+        "colorscale": {
+          "diverging": [
+            [
+              0.0,
+              "rgb(103,0,31)"
+            ],
+            [
+              0.1,
+              "rgb(178,24,43)"
+            ],
+            [
+              0.2,
+              "rgb(214,96,77)"
+            ],
+            [
+              0.3,
+              "rgb(244,165,130)"
+            ],
+            [
+              0.4,
+              "rgb(253,219,199)"
+            ],
+            [
+              0.5,
+              "rgb(247,247,247)"
+            ],
+            [
+              0.6,
+              "rgb(209,229,240)"
+            ],
+            [
+              0.7,
+              "rgb(146,197,222)"
+            ],
+            [
+              0.8,
+              "rgb(67,147,195)"
+            ],
+            [
+              0.9,
+              "rgb(33,102,172)"
+            ],
+            [
+              1.0,
+              "rgb(5,48,97)"
+            ]
+          ],
+          "sequential": [
+            [
+              0.0,
+              "#440154"
+            ],
+            [
+              0.1111111111111111,
+              "#482878"
+            ],
+            [
+              0.2222222222222222,
+              "#3e4989"
+            ],
+            [
+              0.3333333333333333,
+              "#31688e"
+            ],
+            [
+              0.4444444444444444,
+              "#26828e"
+            ],
+            [
+              0.5555555555555556,
+              "#1f9e89"
+            ],
+            [
+              0.6666666666666666,
+              "#35b779"
+            ],
+            [
+              0.7777777777777778,
+              "#6ece58"
+            ],
+            [
+              0.8888888888888888,
+              "#b5de2b"
+            ],
+            [
+              1.0,
+              "#fde725"
+            ]
+          ],
+          "sequentialminus": [
+            [
+              0.0,
+              "#440154"
+            ],
+            [
+              0.1111111111111111,
+              "#482878"
+            ],
+            [
+              0.2222222222222222,
+              "#3e4989"
+            ],
+            [
+              0.3333333333333333,
+              "#31688e"
+            ],
+            [
+              0.4444444444444444,
+              "#26828e"
+            ],
+            [
+              0.5555555555555556,
+              "#1f9e89"
+            ],
+            [
+              0.6666666666666666,
+              "#35b779"
+            ],
+            [
+              0.7777777777777778,
+              "#6ece58"
+            ],
+            [
+              0.8888888888888888,
+              "#b5de2b"
+            ],
+            [
+              1.0,
+              "#fde725"
+            ]
+          ]
+        },
+        "colorway": [
+          "#1F77B4",
+          "#FF7F0E",
+          "#2CA02C",
+          "#D62728",
+          "#9467BD",
+          "#8C564B",
+          "#E377C2",
+          "#7F7F7F",
+          "#BCBD22",
+          "#17BECF"
+        ],
+        "font": {
+          "color": "rgb(36,36,36)"
+        },
+        "geo": {
+          "bgcolor": "white",
+          "lakecolor": "white",
+          "landcolor": "white",
+          "showlakes": true,
+          "showland": true,
+          "subunitcolor": "white"
+        },
+        "hoverlabel": {
+          "align": "left"
+        },
+        "hovermode": "closest",
+        "mapbox": {
+          "style": "light"
+        },
+        "paper_bgcolor": "white",
+        "plot_bgcolor": "white",
+        "polar": {
+          "angularaxis": {
+            "gridcolor": "rgb(232,232,232)",
+            "linecolor": "rgb(36,36,36)",
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside"
+          },
+          "bgcolor": "white",
+          "radialaxis": {
+            "gridcolor": "rgb(232,232,232)",
+            "linecolor": "rgb(36,36,36)",
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside"
+          }
+        },
+        "scene": {
+          "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "rgb(232,232,232)",
+            "gridwidth": 2,
+            "linecolor": "rgb(36,36,36)",
+            "showbackground": true,
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside",
+            "zeroline": false,
+            "zerolinecolor": "rgb(36,36,36)"
+          },
+          "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "rgb(232,232,232)",
+            "gridwidth": 2,
+            "linecolor": "rgb(36,36,36)",
+            "showbackground": true,
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside",
+            "zeroline": false,
+            "zerolinecolor": "rgb(36,36,36)"
+          },
+          "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "rgb(232,232,232)",
+            "gridwidth": 2,
+            "linecolor": "rgb(36,36,36)",
+            "showbackground": true,
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside",
+            "zeroline": false,
+            "zerolinecolor": "rgb(36,36,36)"
+          }
+        },
+        "shapedefaults": {
+          "fillcolor": "black",
+          "line": {
+            "width": 0
+          },
+          "opacity": 0.3
+        },
+        "ternary": {
+          "aaxis": {
+            "gridcolor": "rgb(232,232,232)",
+            "linecolor": "rgb(36,36,36)",
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside"
+          },
+          "baxis": {
+            "gridcolor": "rgb(232,232,232)",
+            "linecolor": "rgb(36,36,36)",
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside"
+          },
+          "bgcolor": "white",
+          "caxis": {
+            "gridcolor": "rgb(232,232,232)",
+            "linecolor": "rgb(36,36,36)",
+            "showgrid": false,
+            "showline": true,
+            "ticks": "outside"
+          }
+        },
+        "title": {
+          "x": 0.05
+        },
+        "xaxis": {
+          "automargin": true,
+          "gridcolor": "rgb(232,232,232)",
+          "linecolor": "rgb(36,36,36)",
+          "showgrid": false,
+          "showline": true,
+          "ticks": "outside",
+          "title": {
+            "standoff": 15
+          },
+          "zeroline": false,
+          "zerolinecolor": "rgb(36,36,36)"
+        },
+        "yaxis": {
+          "automargin": true,
+          "gridcolor": "rgb(232,232,232)",
+          "linecolor": "rgb(36,36,36)",
+          "showgrid": false,
+          "showline": true,
+          "ticks": "outside",
+          "title": {
+            "standoff": 15
+          },
+          "zeroline": false,
+          "zerolinecolor": "rgb(36,36,36)"
+        }
+      }
+    },
+    "title": {
+      "text": "Mass Spectrum",
+      "font": {
+        "family": "Helvetica",
+        "size": 18
+      }
+    },
+    "xaxis": {
+      "title": {
+        "text": "mass-to-charge",
+        "font": {
+          "family": "Helvetica",
+          "size": 16
+        }
+      },
+      "tickfont": {
+        "size": 14,
+        "family": "Helvetica"
+      },
+      "gridcolor": "#CCCCCC",
+      "showgrid": true,
+      "showline": true,
+      "linewidth": 1,
+      "linecolor": "black",
+      "ticks": "outside",
+      "tickwidth": 1,
+      "tickcolor": "black",
+      "range": [
+        80.08,
+        126.11999999999999
+      ]
+    },
+    "yaxis": {
+      "title": {
+        "text": "Intensity",
+        "font": {
+          "family": "Helvetica",
+          "size": 16
+        }
+      },
+      "tickfont": {
+        "size": 14,
+        "family": "Helvetica"
+      },
+      "gridcolor": "#CCCCCC",
+      "showgrid": true,
+      "showline": true,
+      "linewidth": 1,
+      "linecolor": "black",
+      "tickwidth": 1,
+      "tickcolor": "black",
+      "range": [
+        0,
+        115.0
+      ]
+    },
+    "width": 500,
+    "height": 500,
+    "dragmode": "select",
+    "legend": {
+      "font": {
+        "size": 10,
+        "family": "Helvetica"
+      },
+      "title": {
+        "text": "Trace"
+      }
+    },
+    "showlegend": true,
+    "font": {
+      "family": "Helvetica"
+    },
+    "plot_bgcolor": "#FFFFFF",
+    "annotations": [
+      {
+        "font": {
+          "color": "black",
+          "family": "Open Sans Mono, monospace",
+          "size": 12
+        },
+        "showarrow": false,
+        "text": "105.0",
+        "x": 105.0,
+        "xanchor": "left",
+        "y": 100.0
+      },
+      {
+        "font": {
+          "color": "black",
+          "family": "Open Sans Mono, monospace",
+          "size": 12
+        },
+        "showarrow": false,
+        "text": "105.1",
+        "x": 105.1,
+        "xanchor": "left",
+        "y": 90.0
+      },
+      {
+        "font": {
+          "color": "black",
+          "family": "Open Sans Mono, monospace",
+          "size": 12
+        },
+        "showarrow": false,
+        "text": "100.2",
+        "x": 100.2,
+        "xanchor": "left",
+        "y": 50.0
+      },
+      {
+        "font": {
+          "color": "black",
+          "family": "Open Sans Mono, monospace",
+          "size": 12
+        },
+        "showarrow": false,
+        "text": "100.1",
+        "x": 100.1,
+        "xanchor": "left",
+        "y": 10.0
+      }
+    ],
+    "shapes": [
+      {
+        "line": {
+          "color": "#EEEEEE",
+          "width": 2
+        },
+        "opacity": 1,
+        "type": "line",
+        "x0": 0,
+        "x1": 1,
+        "xref": "x domain",
+        "y0": 0,
+        "y1": 0,
+        "yref": "y"
+      }
+    ]
+  }
+}

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -1,7 +1,8 @@
 import pytest
 import pandas as pd
 import json
-
+if not str(pd.options.plotting.backend).startswith("ms_"):
+    pd.options.plotting.backend = "ms_plotly"
 # Skip these tests if the user doesn't have Polars or PyArrow installed
 pl = pytest.importorskip("polars")
 pytest.importorskip("pyarrow")
@@ -38,25 +39,30 @@ def test_polars_ms_plot_accessor():
     assert fig is not None
     assert type(fig).__name__ == "Figure"
 
-def test_polars_vs_pandas_snapshot():
+def test_polars_ms_plot_snapshot(snapshot):
     """
-    Test that Polars ms_plot() and Pandas plot() generate the exact same
-    underlying Plotly figure data (snapshot test).
+    Test that Polars ms_plot() generates a stable figure
+    using the syrupy snapshot testing framework.
     """
     data = {
         "m/z": [100.1, 100.2, 105.0, 105.1],
         "intensity": [10.0, 50.0, 100.0, 90.0]
     }
     
-    df_pd = pd.DataFrame(data)
     df_pl = pl.DataFrame(data)
     
-    fig_pd = df_pd.plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly", show_plot=False)
-    fig_pl = df_pl.ms_plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly", show_plot=False)
+    # Generate the figure using the Polars accessor
+    out = df_pl.ms_plot(
+        kind="spectrum", 
+        x="m/z", 
+        y="intensity", 
+        show_plot=False
+    )
     
-    # Parse the JSON strings into Python dictionaries to avoid strict string-ordering issues
-    dict_pd = json.loads(fig_pd.to_json())
-    dict_pl = json.loads(fig_pl.to_json())
-    
-    # Compare the core data arrays to guarantee the delegation plotted the exact same values
-    assert dict_pd["data"] == dict_pl["data"]
+    # Apply tight layout to matplotlib to ensure it is not cut off (matches repo standards)
+    if pd.options.plotting.backend == "ms_matplotlib":
+        fig = out.get_figure()
+        fig.tight_layout()
+
+    # Let syrupy handle the serialization and comparison
+    assert snapshot == out

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -22,7 +22,7 @@ def test_polars_ms_plot_accessor():
         kind="spectrum", 
         x="m/z", 
         y="intensity", 
-        backend="plotly"
+        backend="ms_plotly"
     )
     
     # 3. Assert that the delegation worked and returned a valid Figure object

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -4,7 +4,7 @@ import pytest
 pl = pytest.importorskip("polars")
 pytest.importorskip("pyarrow")
 
-import pyopenms_viz 
+import pyopenms_viz
 
 def test_polars_ms_plot_accessor():
     """

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -1,6 +1,7 @@
 import pytest
+import pandas as pd
 
-# Skip this entire test if the user doesn't have Polars or PyArrow installed
+# Skip these tests if the user doesn't have Polars or PyArrow installed
 pl = pytest.importorskip("polars")
 pytest.importorskip("pyarrow")
 
@@ -11,20 +12,39 @@ def test_polars_ms_plot_accessor():
     Test that the ms_plot namespace is properly registered for Polars DataFrames
     and successfully delegates to the underlying pandas plotting backend.
     """
-    # 1. Create a tiny dummy Polars DataFrame
     df_pl = pl.DataFrame({
         "m/z": [100.1, 100.2, 105.0, 105.1],
         "intensity": [10.0, 50.0, 100.0, 90.0]
     })
-    
-    # 2. Call our brand new accessor!
+
     fig = df_pl.ms_plot(
-        kind="spectrum", 
-        x="m/z", 
-        y="intensity", 
+        kind="spectrum",
+        x="m/z",
+        y="intensity",
         backend="ms_plotly"
     )
-    
-    # 3. Assert that the delegation worked and returned a valid Figure object
+
     assert fig is not None
     assert type(fig).__name__ == "Figure"
+
+def test_polars_vs_pandas_snapshot():
+    """
+    Test that Polars ms_plot() and Pandas plot() generate the exact same
+    underlying Plotly figure data (snapshot test).
+    """
+    data = {
+        "m/z": [100.1, 100.2, 105.0, 105.1],
+        "intensity": [10.0, 50.0, 100.0, 90.0]
+    }
+
+    # Create identical DataFrames
+    df_pd = pd.DataFrame(data)
+    df_pl = pl.DataFrame(data)
+
+    # Generate figures
+    fig_pd = df_pd.plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly")
+    fig_pl = df_pl.ms_plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly")
+
+    # Compare the underlying JSON structure of the figures.
+    # This guarantees the Polars delegation yields 100% identical Plotly output.
+    assert fig_pd.to_json() == fig_pl.to_json()

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -1,22 +1,23 @@
 import pytest
 import pandas as pd
-import json
-if not str(pd.options.plotting.backend).startswith("ms_"):
-    pd.options.plotting.backend = "ms_plotly"
+
 # Skip these tests if the user doesn't have Polars or PyArrow installed
 pl = pytest.importorskip("polars")
 pytest.importorskip("pyarrow")
-
-import pyopenms_viz
-
 @pytest.fixture(autouse=True)
 def load_backend():
     """
-    Override the parametrized autouse `load_backend` fixture from `conftest.py`
-    so that tests in this module run only once. These tests explicitly pass
-    backend="ms_plotly", so no additional setup is required.
+    Safely override the global backend so the syrupy snapshot fixture
+    in conftest.py knows which extension to load, then reset it
+    to avoid leaking state to other tests.
     """
+    original_backend = pd.options.plotting.backend
+    pd.options.plotting.backend = "ms_plotly"
+    
     yield
+    
+    # Teardown: restore the original state
+    pd.options.plotting.backend = original_backend
 
 def test_polars_ms_plot_accessor():
     """
@@ -41,7 +42,7 @@ def test_polars_ms_plot_accessor():
 
 def test_polars_ms_plot_snapshot(snapshot):
     """
-    Test that Polars ms_plot() generates a stable figure
+    Test that Polars ms_plot() generates a stable Plotly figure
     using the syrupy snapshot testing framework.
     """
     data = {
@@ -56,13 +57,9 @@ def test_polars_ms_plot_snapshot(snapshot):
         kind="spectrum", 
         x="m/z", 
         y="intensity", 
+        backend="ms_plotly",  # Explicitly set backend to avoid global state leaks
         show_plot=False
     )
-    
-    # Apply tight layout to matplotlib to ensure it is not cut off (matches repo standards)
-    if pd.options.plotting.backend == "ms_matplotlib":
-        fig = out.get_figure()
-        fig.tight_layout()
 
     # Let syrupy handle the serialization and comparison
     assert snapshot == out

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+import json
 
 # Skip these tests if the user doesn't have Polars or PyArrow installed
 pl = pytest.importorskip("polars")
@@ -12,9 +13,10 @@ def load_backend():
     """
     Override the parametrized autouse `load_backend` fixture from `conftest.py`
     so that tests in this module run only once. These tests explicitly pass
-    backend="ms_plotly", so no additional setup is required here.
+    backend="ms_plotly", so no additional setup is required.
     """
     yield
+
 def test_polars_ms_plot_accessor():
     """
     Test that the ms_plot namespace is properly registered for Polars DataFrames
@@ -24,14 +26,15 @@ def test_polars_ms_plot_accessor():
         "m/z": [100.1, 100.2, 105.0, 105.1],
         "intensity": [10.0, 50.0, 100.0, 90.0]
     })
-
+    
     fig = df_pl.ms_plot(
-        kind="spectrum",
-        x="m/z",
-        y="intensity",
-        backend="ms_plotly"
+        kind="spectrum", 
+        x="m/z", 
+        y="intensity", 
+        backend="ms_plotly",
+        show_plot=False
     )
-
+    
     assert fig is not None
     assert type(fig).__name__ == "Figure"
 
@@ -44,15 +47,16 @@ def test_polars_vs_pandas_snapshot():
         "m/z": [100.1, 100.2, 105.0, 105.1],
         "intensity": [10.0, 50.0, 100.0, 90.0]
     }
-
-    # Create identical DataFrames
+    
     df_pd = pd.DataFrame(data)
     df_pl = pl.DataFrame(data)
-
-    # Generate figures
-    fig_pd = df_pd.plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly")
-    fig_pl = df_pl.ms_plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly")
-
-    # Compare the underlying JSON structure of the figures.
-    # This guarantees the Polars delegation yields 100% identical Plotly output.
-    assert fig_pd.to_json() == fig_pl.to_json()
+    
+    fig_pd = df_pd.plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly", show_plot=False)
+    fig_pl = df_pl.ms_plot(kind="spectrum", x="m/z", y="intensity", backend="ms_plotly", show_plot=False)
+    
+    # Parse the JSON strings into Python dictionaries to avoid strict string-ordering issues
+    dict_pd = json.loads(fig_pd.to_json())
+    dict_pl = json.loads(fig_pl.to_json())
+    
+    # Compare the core data arrays to guarantee the delegation plotted the exact same values
+    assert dict_pd["data"] == dict_pl["data"]

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -1,0 +1,30 @@
+import pytest
+
+# Skip this entire test if the user doesn't have Polars or PyArrow installed
+pl = pytest.importorskip("polars")
+pytest.importorskip("pyarrow")
+
+import pyopenms_viz 
+
+def test_polars_ms_plot_accessor():
+    """
+    Test that the ms_plot namespace is properly registered for Polars DataFrames
+    and successfully delegates to the underlying pandas plotting backend.
+    """
+    # 1. Create a tiny dummy Polars DataFrame
+    df_pl = pl.DataFrame({
+        "m/z": [100.1, 100.2, 105.0, 105.1],
+        "intensity": [10.0, 50.0, 100.0, 90.0]
+    })
+    
+    # 2. Call our brand new accessor!
+    fig = df_pl.ms_plot(
+        kind="spectrum", 
+        x="m/z", 
+        y="intensity", 
+        backend="ms_plotly"
+    )
+    
+    # 3. Assert that the delegation worked and returned a valid Figure object
+    assert fig is not None
+    assert type(fig).__name__ == "Figure"

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -22,7 +22,7 @@ def test_polars_ms_plot_accessor():
         kind="spectrum", 
         x="m/z", 
         y="intensity", 
-        backend="ms_plotly"
+        backend="plotly"
     )
     
     # 3. Assert that the delegation worked and returned a valid Figure object

--- a/test/test_polars_accessor.py
+++ b/test/test_polars_accessor.py
@@ -7,6 +7,14 @@ pytest.importorskip("pyarrow")
 
 import pyopenms_viz
 
+@pytest.fixture(autouse=True)
+def load_backend():
+    """
+    Override the parametrized autouse `load_backend` fixture from `conftest.py`
+    so that tests in this module run only once. These tests explicitly pass
+    backend="ms_plotly", so no additional setup is required here.
+    """
+    yield
 def test_polars_ms_plot_accessor():
     """
     Test that the ms_plot namespace is properly registered for Polars DataFrames


### PR DESCRIPTION
Resolves #55

Technical Overview
Namespace Extension: Registered a custom ms_plot namespace for Polars DataFrames to avoid collisions with Polars' internal .plot (Altair) API.

Safe Delegation: Implemented an upfront conversion to Pandas via pyarrow within the accessor. This ensures full compatibility with the existing BasePlot architecture and legacy Pandas-specific manipulations.

Consistent Style: Updated requirements.txt with version locks (polars==1.38.1, pyarrow==23.0.1) following the project's existing formatting.

Dynamic Dependencies: Utilized a try-except wrapper in _polars_accessor.py to ensure Polars remains an optional dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Polars DataFrame support: call the plotting API directly on Polars dataframes to produce the same visualizations as with pandas; no-op if Polars isn’t installed.

* **Tests**
  * Added tests to validate the Polars plotting accessor and its delegation to the plotting backend.

* **Chores**
  * Added packages required to enable the Polars integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->